### PR TITLE
fix(deps): upgrade cryptography to 46.0.5 to fix CVE-2026-26007

### DIFF
--- a/source/src/notebook/healthcare-and-life-sciences/c-1-protein-folding-quantum-random-walk/requirements.txt
+++ b/source/src/notebook/healthcare-and-life-sciences/c-1-protein-folding-quantum-random-walk/requirements.txt
@@ -25,7 +25,7 @@ certifi==2024.7.4
 cffi==1.15.1
 charset-normalizer==2.0.12
 contextvars==2.4
-cryptography==44.0.1
+cryptography==46.0.5
 cycler==0.11.0
 debugpy==1.6.6
 decorator==5.1.1


### PR DESCRIPTION
## Summary

- Upgrades `cryptography` from 44.0.1 to 46.0.5 in the protein-folding notebook requirements
- Fixes [CVE-2026-26007](https://github.com/awslabs/quantum-computing-exploration-for-drug-discovery-on-aws/security/dependabot/556): high-severity subgroup attack vulnerability due to missing subgroup validation for SECT curves

## Test plan

- [ ] Verify the protein-folding notebook (`c-1-protein-folding-quantum-random-walk`) installs dependencies successfully with the updated `cryptography` version
- [ ] Confirm no import or compatibility regressions in notebook execution