### PR TITLE
fix(deps): upgrade 6 packages to resolve 8 Dependabot security alerts

### DIFF
--- a/source/src/notebook/healthcare-and-life-sciences/c-1-protein-folding-quantum-random-walk/requirements.txt
+++ b/source/src/notebook/healthcare-and-life-sciences/c-1-protein-folding-quantum-random-walk/requirements.txt
@@ -25,7 +25,7 @@ certifi==2024.7.4
 cffi==1.15.1
 charset-normalizer==2.0.12
 contextvars==2.4
-cryptography==46.0.5
+cryptography==46.0.7
 cycler==0.11.0
 debugpy==1.6.6
 decorator==5.1.1
@@ -60,12 +60,12 @@ jupyter-server==2.11.2
 jupyterlab==4.4.8
 jupyterlab-pygments==0.1.2
 jupyterlab-server==2.10.3
-Keras==3.13.1
+Keras==3.13.2
 Keras-Applications==1.0.8
 Keras-Preprocessing==1.1.2
 kiwisolver==1.3.1
 lxml==4.9.2
-Markdown==3.3.7
+Markdown==3.8.1
 MarkupSafe==2.0.1
 matplotlib==3.3.4
 matplotlib-inline==0.1.6
@@ -102,10 +102,10 @@ prompt-toolkit==3.0.36
 protobuf==6.33.5
 psutil==5.9.4
 ptyprocess==0.7.0
-pyasn1==0.4.8
+pyasn1==0.6.3
 pycparser==2.21
 pydantic==1.10.13
-Pygments==2.15.0
+Pygments==2.20.0
 pyparsing==3.0.9
 pyrsistent==0.18.0
 python-constraint==1.4.0
@@ -119,7 +119,7 @@ qiskit-aqua==0.9.5
 qiskit-ibmq-provider==0.18.3
 qiskit-ignis==0.7.0
 Quandl==3.7.0
-requests==2.32.4
+requests==2.33.0
 requests-ntlm==1.1.0
 retworkx==0.11.0
 s3transfer==0.5.2


### PR DESCRIPTION
## Summary

- Upgrade **cryptography** 46.0.5 → 46.0.7 to fix buffer overflow with non-contiguous buffers and incomplete DNS name constraint enforcement
- Upgrade **Keras** 3.13.1 → 3.13.2 to fix untrusted deserialization and local file disclosure via HDF5 external storage
- Upgrade **pyasn1** 0.4.8 → 0.6.3 to fix denial of service via unbounded recursion
- Upgrade **Markdown** 3.3.7 → 3.8.1 to fix uncaught exception
- Upgrade **requests** 2.32.4 → 2.33.0 to fix insecure temp file reuse in `extract_zipped_paths()`
- Upgrade **Pygments** 2.15.0 → 2.20.0 to fix ReDoS via inefficient regex for GUID matching

Resolves Dependabot alerts: #560, #570, #574, #585, #591, #594, #595, #599

## Test plan

- [ ] Verify CDK synth completes successfully
- [ ] Verify the c-1 protein folding notebook runs with upgraded dependencies
- [ ] Confirm all 8 Dependabot alerts are auto-closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)